### PR TITLE
update puppetlabs release rpm path construction for EL9

### DIFF
--- a/provisioning_templates/snippet/puppetlabs_repo.erb
+++ b/provisioning_templates/snippet/puppetlabs_repo.erb
@@ -38,21 +38,17 @@ end
 
 if host_param_true?('enable-puppetlabs-repo')
   repo_name = 'puppet-release'
-  repo_subdir = ''
 elsif host_param_true?('enable-official-puppet7-repo')
   repo_name = 'puppet7-release'
-  repo_subdir = 'puppet7/'
 elsif host_param_true?('enable-puppetlabs-puppet6-repo')
   repo_name = 'puppet6-release'
-  repo_subdir = 'puppet6/'
 elsif host_param_true?('enable-puppetlabs-puppet5-repo')
   repo_name = 'puppet5-release'
-  repo_subdir = 'puppet5/'
 end
 -%>
 <% if repo_name -%>
 <% if os_family == 'Redhat' || os_name == 'SLES' -%>
-rpm -Uvh<%= http_proxy %><%= http_port %> https://<%= repo_host %>/<%= repo_subdir %><%= repo_name %>-<%= repo_os %>-<%= os_major %>.noarch.rpm
+rpm -Uvh<%= http_proxy %><%= http_port %> https://<%= repo_host %>/<%= repo_name %>-<%= repo_os %>-<%= os_major %>.noarch.rpm
 <% elsif os_family == 'Debian' -%>
 apt-get update
 apt-get -y install ca-certificates


### PR DESCRIPTION
The http://yum.puppet.com/puppet7 directory does not contain an rpm for EL9. In other words, this URL constructed using the current logic is a 404:

  https://yum.puppet.com/puppet7/puppet7-release-el-9.noarch.rpm

There are packages for EL5 through EL9 in the root of the repo. E.g.:

  http://yum.puppet.com/puppet7-release-el-9.noarch.rpm

This simple fix is to drop usage of a "puppet<ELX>" subdir for all major EL versions.