### PR TITLE
(kickstart_boot+data_by-id_wip) make data_disk_id host_param optional

### DIFF
--- a/partition_tables_templates/kickstart_boot+data_by-id_wip.erb
+++ b/partition_tables_templates/kickstart_boot+data_by-id_wip.erb
@@ -22,22 +22,29 @@ echo "###" | nc <%= foreman_server_fqdn %> 8999 || true
 BOOT_DEV="/dev/disk/by-id/<%= host_param('boot_disk_id') %>"
 BOOT_VG="boot_$(hostname -s)"
 
+<% if host_param('data_disk_id') %>"
 DATA_DEV="/dev/disk/by-id/<%= host_param('data_disk_id') %>"
 DATA_VG="data_$(hostname -s)"
 DATA_PATH="<%= host_param('data_path') or '/data' %>"
+ALL_DEVS="${BOOT_DEV},${DATA_DEV}"
+<% else%>
+ALL_DEVS="${BOOT_DEV}"
+<% end %>
 
 cat <<EOF > /tmp/diskpart.cfg
-ignoredisk --only-use=${BOOT_DEV},${DATA_DEV}
+ignoredisk --only-use=${ALL_DEVS}
 zerombr
-clearpart --drives=${BOOT_DEV},${DATA_DEV} --all --initlabel --disklabel=gpt
+clearpart --drives=${ALL_DEVS} --all --initlabel --disklabel=gpt
 
 part /boot     --size=1024 --asprimary --ondrive=${BOOT_DEV} --fstype=ext4
 part /boot/efi --size=200  --asprimary --ondrive=${BOOT_DEV} --fstype=efi
 part pv.boot   --size=1 --grow --ondisk=${BOOT_DEV}
-part pv.data   --size=1 --grow --ondisk=${DATA_DEV}
-
 volgroup ${BOOT_VG} pv.boot
+
+<% if host_param('data_disk_id') %>"
+part pv.data   --size=1 --grow --ondisk=${DATA_DEV}
 volgroup ${DATA_VG} pv.data
+<% end %>
 
 logvol /               --vgname=${BOOT_VG} --size=<%= host_param('root_lv_size') or 51200 %> --name=root --fstype=ext4
 <% if host_param('home_lv_size') -%>
@@ -49,5 +56,7 @@ logvol /var            --vgname=${BOOT_VG} --size=<%= host_param('var_lv_size') 
 <% if host_param('docker_lv_size') -%>
 logvol /var/lib/docker --vgname=${BOOT_VG} --size=<%= host_param('docker_lv_size') %> --name=docker
 <% end -%>
+<% if host_param('data_disk_id') %>"
 logvol ${DATA_PATH}    --vgname=${DATA_VG} --size=1 --grow --name=data --fstype=xfs
+<% end %>
 EOF


### PR DESCRIPTION
This change allows the same partition table template to be used for nodes with a single drive and nodes with a boot + data drive.